### PR TITLE
chore: ci优化 删除不需要触发的分支 v*的分支也会触发publish-to-pkg-pr ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,7 @@ name: autofix.ci
 on:
   push:
     branches:
-      - main
-      - develop
+      - main      
 
 permissions:
   contents: read

--- a/.github/workflows/publish-to-pkg-pr.yml
+++ b/.github/workflows/publish-to-pkg-pr.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - next
+      - v*
   pull_request:
     branches:
       - main
-      - next
+      - v*
 
   merge_group: {}
 


### PR DESCRIPTION
closes #20