### PR TITLE
提供一个 getDsl 方法用于获取当前页面的 dsl 直接从 @zelpis/core 导出（仅支持 csr 模式下）

### DIFF
--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -59,7 +59,7 @@ plugins: [...zelpisPlugin({ build: {}, render: { baseDir: './' } })]
 ### DSL 工具
 
 ```typescript
-import { defineDsl, mergeDsl } from '@zelpis/core/dsl'
+import { defineDsl, mergeDsl, getDsl } from '@zelpis/core/dsl'
 ```
 ## 内置模块说明
 

--- a/docs/packages/render.md
+++ b/docs/packages/render.md
@@ -111,7 +111,7 @@ const pageDsl = mergeDsl(baseDsl, { title: 'Page', data: { b: 2 } })
 获取当前页面的 DSL（CSR）。直接读取 HTML 注入的 `window.$zelpis.hydrateData.dsl`。
 
 ```typescript
-import { getDsl } from '@zelpis/core/dsl'
+import { getDsl } from '@zelpis/render/dsl'
 
 const dsl = getDsl()
 ```

--- a/docs/packages/render.md
+++ b/docs/packages/render.md
@@ -106,6 +106,18 @@ const pageDsl = mergeDsl(baseDsl, { title: 'Page', data: { b: 2 } })
 // 结果: { title: 'Page', data: { b: 2 } }
 ```
 
+### `getDsl()`
+
+获取当前页面的 DSL（CSR）。直接读取 HTML 注入的 `window.$zelpis.hydrateData.dsl`。
+
+```typescript
+import { getDsl } from '@zelpis/core/dsl'
+
+const dsl = getDsl()
+```
+
+后续若支持 SSR/SSG，需另行设计（Node 环境无 `window`，不能沿用当前实现）。
+
 ### `loadDsl(modelDir, dslName)`（`@zelpis/render/dsl/server`）
 
 Node 环境下加载 DSL 模块，用于构建时解析 DSL 配置。

--- a/examples/vue-example/app.vue
+++ b/examples/vue-example/app.vue
@@ -1,10 +1,11 @@
 <script setup>
-const data = window.$zelpis.hydrateData
+import { getDsl } from '@zelpis/core/dsl'
+const url = getDsl()
 </script>
 
 <template>
   <div>
-    123 {{ data }}
+    123 {{ url }}
     <router-view />
   </div>
 </template>

--- a/packages/render/src/boot.ts
+++ b/packages/render/src/boot.ts
@@ -84,7 +84,6 @@ function csrRenderer(option: BootOption): { option: BootOption, render: () => { 
   option.type = 'csr'
 
   const csrRender = async (): Promise<void> => {
-    // @ts-expect-error any
     const props = { ...window.$zelpis.hydrateData }
     const Comp = await createComponent(framework, Component, props, option)
     if (framework === 'react') {

--- a/packages/render/src/dsl/get-dsl.ts
+++ b/packages/render/src/dsl/get-dsl.ts
@@ -5,6 +5,9 @@ import type { DSL } from './define'
  * 读取 HTML 注入的 `window.$zelpis.hydrateData.dsl`。
  */
 export function getDsl<T extends Record<string, any> = DSL>(): T {
+  if (typeof window === 'undefined') {
+    throw new Error('仅支持在浏览器环境中使用')
+  }
   const dsl = window.$zelpis?.hydrateData?.dsl
   if (dsl !== undefined) {
     return dsl as T

--- a/packages/render/src/dsl/get-dsl.ts
+++ b/packages/render/src/dsl/get-dsl.ts
@@ -1,0 +1,13 @@
+import type { DSL } from './define'
+
+/**
+ * 获取当前页面的 DSL（CSR）。
+ * 读取 HTML 注入的 `window.$zelpis.hydrateData.dsl`。
+ */
+export function getDsl<T extends Record<string, any> = DSL>(): T {
+  const dsl = window.$zelpis?.hydrateData?.dsl
+  if (dsl !== undefined) {
+    return dsl as T
+  }
+  throw new Error('DSL not found')
+}

--- a/packages/render/src/dsl/index.ts
+++ b/packages/render/src/dsl/index.ts
@@ -1,2 +1,3 @@
 export * from './define'
+export { getDsl } from './get-dsl'
 export * from './merge'

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,2 +1,3 @@
 export * from './boot'
 export * from './dsl/define'
+export { getDsl } from './dsl/get-dsl'

--- a/packages/render/types.d.ts
+++ b/packages/render/types.d.ts
@@ -8,3 +8,12 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface Window {
+  $zelpis: {
+    hydrateData: {
+      dsl?: Record<string, unknown>
+      [key: string]: unknown
+    }
+  }
+}


### PR DESCRIPTION
提供一个 getDsl 方法用于获取当前页面的 dsl 直接从 @zelpis/core 导出（仅支持 csr 模式下）
#28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `getDsl()`：在客户端渲染场景读取页面注入的 DSL，并在缺失时抛出明确错误。

* **文档**
  * 更新核心与渲染文档，补充 `getDsl()` 的 CSR 用法及限制说明。
  * 调整相关示例以展示基于 `getDsl()` 的数据获取方式。

* **改进 / 修复**
  * 优化客户端渲染中 DSL/参数读取的类型处理，提升获取过程的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->